### PR TITLE
Add Siri View and remove unnecessary colorMode check

### DIFF
--- a/MSHFConfig.m
+++ b/MSHFConfig.m
@@ -89,8 +89,14 @@
   NSLog(@"[Mitsuha] self.colorMode: %d", self.colorMode);
 
   if (self.colorMode == 2 && self.waveColor) {
-    [_view updateWaveColor:[self.waveColor copy]
-              subwaveColor:[self.waveColor copy]];
+    if (self.style == 4) {
+      [_view updateWaveColor:[self.waveColor copy]
+                subwaveColor:[self.waveColor copy]
+             subSubwaveColor:[self.waveColor copy]];
+    } else {
+      [_view updateWaveColor:[self.waveColor copy]
+                subwaveColor:[self.waveColor copy]];
+    }
   } else if (self.colorMode == 1 && self.waveColor && self.subwaveColor && self.subSubwaveColor) {
     [_view updateWaveColor:[self.waveColor copy]
               subwaveColor:[self.waveColor copy]

--- a/MSHFConfig.m
+++ b/MSHFConfig.m
@@ -55,6 +55,9 @@
     self.view = [[MSHFDotView alloc] initWithFrame:frame];
     [((MSHFDotView *)_view) setBarSpacing:self.barSpacing];
     break;
+  case 4:
+    self.view = [[MSHFSiriView alloc] initWithFrame:frame];
+    break;
   default:
     self.view = [[MSHFJelloView alloc] initWithFrame:frame];
   }
@@ -82,14 +85,15 @@
   _view.disableBatterySaver = self.disableBatterySaver;
   NSLog(@"[Mitsuha] self.waveColor: %@", self.waveColor);
   NSLog(@"[Mitsuha] self.subwaveColor: %@", self.subwaveColor);
+  NSLog(@"[Mitsuha] self.subSubwaveColor: %@", self.subSubwaveColor);
   NSLog(@"[Mitsuha] self.colorMode: %d", self.colorMode);
 
-  if (self.colorMode == 2 && self.waveColor) {
-    [_view updateWaveColor:[self.waveColor copy]
-              subwaveColor:[self.waveColor copy]];
+  if (self.colorMode == 0 && self.waveColor && self.subwaveColor) {
+    [_view updateWaveColor:[self.waveColor copy] subwaveColor:[self.waveColor copy]];
   } else if (self.calculatedColor) {
-    [_view updateWaveColor:[self.calculatedColor copy]
-              subwaveColor:[self.calculatedColor copy]];
+    [_view updateWaveColor:[self.calculatedColor copy] subwaveColor:[self.calculatedColor copy] subSubwaveColor:[self.calculatedColor copy]];
+  } else if (self.colorMode == 1 && self.waveColor && self.subwaveColor && self.subSubwaveColor) {
+    [_view updateWaveColor:[self.waveColor copy] subwaveColor:[self.waveColor copy] subSubwaveColor:[self.waveColor copy]];
   }
 }
 - (UIColor *)getAverageColorFrom:(UIImage *)image withAlpha:(double)alpha {
@@ -114,13 +118,24 @@
   if (self.view == NULL)
     return;
   UIColor *color = self.waveColor;
-  if (self.colorMode != 2) {
+  UIColor *scolor = self.waveColor;
+  UIColor *sscolor = self.waveColor;
+  if (self.colorMode == 1 && self.style == 4) {
+    color = [UIColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:self.dynamicColorAlpha];
+    scolor = [UIColor colorWithRed:0.0f green:1.0f blue:0.0f alpha:self.dynamicColorAlpha];
+    sscolor = [UIColor colorWithRed:0.0f green:0.0f blue:1.0f alpha:self.dynamicColorAlpha];
+  } else {
     color = [self getAverageColorFrom:image
-                                withAlpha:self.dynamicColorAlpha];
-
-    self.calculatedColor = color;
+                            withAlpha:self.dynamicColorAlpha];
   }
-  [self.view updateWaveColor:[color copy] subwaveColor:[color copy]];
+  self.calculatedColor = color;
+  if (self.colorMode == 1 && self.style == 4) {
+    [self.view updateWaveColor:[color copy] subwaveColor:[scolor copy] subSubwaveColor:[sscolor copy]];
+  } else if (self.colorMode != 1 && self.style == 4) {
+    [self.view updateWaveColor:[color copy] subwaveColor:[color copy] subSubwaveColor:[color copy]];
+  } else {
+    [self.view updateWaveColor:[color copy] subwaveColor:[color copy]];
+  }
 }
 
 - (void)setDictionary:(NSDictionary *)dict {
@@ -220,6 +235,7 @@
 
   prefs[@"gain"] = [prefs objectForKey:@"gain"] ?: @(50);
   prefs[@"subwaveColor"] = prefs[@"waveColor"];
+  prefs[@"subSubwaveColor"] = prefs[@"waveColor"];
   prefs[@"waveOffset"] = ([prefs objectForKey:@"waveOffset"] ?: @(0));
 
   return prefs;

--- a/MSHFConfig.m
+++ b/MSHFConfig.m
@@ -88,12 +88,16 @@
   NSLog(@"[Mitsuha] self.subSubwaveColor: %@", self.subSubwaveColor);
   NSLog(@"[Mitsuha] self.colorMode: %d", self.colorMode);
 
-  if (self.colorMode == 0 && self.waveColor && self.subwaveColor) {
-    [_view updateWaveColor:[self.waveColor copy] subwaveColor:[self.waveColor copy]];
-  } else if (self.calculatedColor) {
-    [_view updateWaveColor:[self.calculatedColor copy] subwaveColor:[self.calculatedColor copy] subSubwaveColor:[self.calculatedColor copy]];
+  if (self.colorMode == 2 && self.waveColor) {
+    [_view updateWaveColor:[self.waveColor copy]
+              subwaveColor:[self.waveColor copy]];
   } else if (self.colorMode == 1 && self.waveColor && self.subwaveColor && self.subSubwaveColor) {
-    [_view updateWaveColor:[self.waveColor copy] subwaveColor:[self.waveColor copy] subSubwaveColor:[self.waveColor copy]];
+    [_view updateWaveColor:[self.waveColor copy]
+              subwaveColor:[self.waveColor copy]
+           subSubwaveColor:[self.waveColor copy]];
+  } else if (self.calculatedColor) {
+    [_view updateWaveColor:[self.calculatedColor copy]
+              subwaveColor:[self.calculatedColor copy]];
   }
 }
 - (UIColor *)getAverageColorFrom:(UIImage *)image withAlpha:(double)alpha {
@@ -121,20 +125,40 @@
   UIColor *scolor = self.waveColor;
   UIColor *sscolor = self.waveColor;
   if (self.colorMode == 1 && self.style == 4) {
-    color = [UIColor colorWithRed:1.0f green:0.0f blue:0.0f alpha:self.dynamicColorAlpha];
-    scolor = [UIColor colorWithRed:0.0f green:1.0f blue:0.0f alpha:self.dynamicColorAlpha];
-    sscolor = [UIColor colorWithRed:0.0f green:0.0f blue:1.0f alpha:self.dynamicColorAlpha];
+    color = [UIColor colorWithRed:1.0f
+                            green:0.0f
+                             blue:0.0f
+                            alpha:self.dynamicColorAlpha];
+    scolor = [UIColor colorWithRed:0.0f
+                             green:1.0f
+                              blue:0.0f
+                             alpha:self.dynamicColorAlpha];
+    sscolor = [UIColor colorWithRed:0.0f
+                              green:0.0f
+                               blue:1.0f
+                              alpha:self.dynamicColorAlpha];
+  } else if (self.colorMode == 2) { // placeholder for custom color
+    color = [self getAverageColorFrom:image
+                            withAlpha:self.dynamicColorAlpha];
   } else {
     color = [self getAverageColorFrom:image
                             withAlpha:self.dynamicColorAlpha];
   }
   self.calculatedColor = color;
   if (self.colorMode == 1 && self.style == 4) {
-    [self.view updateWaveColor:[color copy] subwaveColor:[scolor copy] subSubwaveColor:[sscolor copy]];
+    [self.view updateWaveColor:[color copy]
+                  subwaveColor:[scolor copy]
+               subSubwaveColor:[sscolor copy]];
   } else if (self.colorMode != 1 && self.style == 4) {
-    [self.view updateWaveColor:[color copy] subwaveColor:[color copy] subSubwaveColor:[color copy]];
+    [self.view updateWaveColor:[color copy]
+                  subwaveColor:[color copy]
+               subSubwaveColor:[color copy]];
+  } else if (self.colorMode == 2) { // placeholder for custom color
+    [self.view updateWaveColor:[color copy]
+                  subwaveColor:[color copy]];
   } else {
-    [self.view updateWaveColor:[color copy] subwaveColor:[color copy]];
+    [self.view updateWaveColor:[color copy]
+                  subwaveColor:[color copy]];
   }
 }
 
@@ -180,6 +204,20 @@
     } else if ([[dict objectForKey:@"subwaveColor"]
                    isKindOfClass:[NSString class]]) {
       _subwaveColor = LCPParseColorString([dict objectForKey:@"subwaveColor"],
+                                          @"#000000:0.5");
+    } else {
+      _subwaveColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
+    }
+  } else {
+    _subwaveColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
+  }
+  
+  if ([dict objectForKey:@"subSubwaveColor"]) {
+    if ([[dict objectForKey:@"subSubwaveColor"] isKindOfClass:[UIColor class]]) {
+      _subwaveColor = [dict objectForKey:@"subSubwaveColor"];
+    } else if ([[dict objectForKey:@"subSubwaveColor"]
+                   isKindOfClass:[NSString class]]) {
+      _subwaveColor = LCPParseColorString([dict objectForKey:@"subSubwaveColor"],
                                           @"#000000:0.5");
     } else {
       _subwaveColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];

--- a/MSHFSiriView.m
+++ b/MSHFSiriView.m
@@ -1,0 +1,185 @@
+#import "public/MSHFSiriView.h"
+
+static CGPoint midPointForPoints(CGPoint p1, CGPoint p2) {
+    return CGPointMake((p1.x + p2.x) / 2, (p1.y + p2.y) / 2);
+}
+
+static CGPoint controlPointForPoints(CGPoint p1, CGPoint p2) {
+    CGPoint controlPoint = midPointForPoints(p1, p2);
+    CGFloat diffY = fabs(p2.y - controlPoint.y);
+    
+    if (p1.y < p2.y)
+        controlPoint.y += diffY;
+    else if (p1.y > p2.y)
+        controlPoint.y -= diffY;
+    
+    return controlPoint;
+}
+
+@implementation MSHFSiriView
+
+-(void)initializeWaveLayers{
+    self.waveLayer = [MSHFJelloLayer layer];
+    self.rWaveLayer = [MSHFJelloLayer layer];
+    self.subwaveLayer = [MSHFJelloLayer layer];
+    self.rSubwaveLayer = [MSHFJelloLayer layer];
+    self.subSubwaveLayer = [MSHFJelloLayer layer];
+    self.rSubSubwaveLayer = [MSHFJelloLayer layer];
+    
+    self.waveLayer.frame = self.subwaveLayer.frame = self.subSubwaveLayer.frame = self.rWaveLayer.frame = self.rSubwaveLayer.frame = self.rSubSubwaveLayer.frame = self.bounds;
+    
+    [self.layer addSublayer:self.waveLayer];
+    [self.layer addSublayer:self.rWaveLayer];
+    [self.layer addSublayer:self.subwaveLayer];
+    [self.layer addSublayer:self.rSubwaveLayer];
+    [self.layer addSublayer:self.subSubwaveLayer];
+    [self.layer addSublayer:self.rSubSubwaveLayer];
+    
+    self.waveLayer.zPosition = 0;
+    self.rWaveLayer.zPosition = 0;
+    self.subwaveLayer.zPosition = -1;
+    self.rSubwaveLayer.zPosition = -1;
+    self.subSubwaveLayer.zPosition = -2;
+    self.rSubSubwaveLayer.zPosition = -2;
+    
+    [self configureDisplayLink];
+    [self resetWaveLayers];
+    
+    self.waveLayer.shouldAnimate = true;
+    self.subwaveLayer.shouldAnimate = true;
+    self.subSubwaveLayer.shouldAnimate = true;
+    self.rWaveLayer.shouldAnimate = true;
+    self.rSubwaveLayer.shouldAnimate = true;
+    self.rSubSubwaveLayer.shouldAnimate = true;
+}
+
+-(void)resetWaveLayers{
+    if (!self.waveLayer || !self.subwaveLayer || !self.subSubwaveLayer || !self.rWaveLayer || !self.rSubwaveLayer || !self.rSubSubwaveLayer) {
+        [self initializeWaveLayers];
+    }
+    
+    CGPathRef path = [self createPathWithPoints:self.points
+                                     pointCount:0
+                                         inRect:self.bounds];
+    
+    NSLog(@"[libmitsuha]: Resetting Wave Layers...");
+    
+    self.waveLayer.path = path;
+    self.rWaveLayer.path = path;
+    self.subwaveLayer.path = path;
+    self.rSubwaveLayer.path = path;
+    self.subSubwaveLayer.path = path;
+    self.rSubSubwaveLayer.path = path;
+}
+
+-(void)updateWaveColor:(UIColor *)waveColor subwaveColor:(UIColor *)subwaveColor subSubwaveColor:(UIColor *)subSubwaveColor{
+    self.waveColor = waveColor;
+    self.subwaveColor = subwaveColor;
+    self.subSubwaveColor = subSubwaveColor;
+    self.waveLayer.fillColor = waveColor.CGColor;
+    self.rWaveLayer.fillColor = waveColor.CGColor;
+    self.subwaveLayer.fillColor = subwaveColor.CGColor;
+    self.rSubwaveLayer.fillColor = subwaveColor.CGColor;
+    self.subSubwaveLayer.fillColor = subSubwaveColor.CGColor;
+    self.rSubSubwaveLayer.fillColor = subSubwaveColor.CGColor;
+    self.waveLayer.compositingFilter = @"screenBlendMode";
+    self.rWaveLayer.compositingFilter = @"screenBlendMode";
+    self.subwaveLayer.compositingFilter = @"screenBlendMode";
+    self.rSubwaveLayer.compositingFilter = @"screenBlendMode";
+    self.subSubwaveLayer.compositingFilter = @"screenBlendMode";
+    self.rSubSubwaveLayer.compositingFilter = @"screenBlendMode";
+}
+
+- (void)redraw{
+    [super redraw];
+    
+    CGPathRef path = [self createPathWithPoints:self.points
+                                     pointCount:self.numberOfPoints
+                                         inRect:self.bounds];
+    CATransform3D scale = CATransform3DMakeScale(1, -1, 1);
+    CATransform3D translate = CATransform3DMakeTranslation(0, self.waveOffset - (self.bounds.size.height - self.waveOffset), 0);
+    CATransform3D transform =  CATransform3DConcat(scale, translate);
+    
+    self.waveLayer.path = path;
+    self.rWaveLayer.path = path;
+    self.rWaveLayer.transform = transform;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.25 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.subwaveLayer.path = path;
+        self.rSubwaveLayer.path = path;
+        self.rSubwaveLayer.transform = transform;
+        // CGPathRelease(path);
+    });
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.subSubwaveLayer.path = path;
+        self.rSubSubwaveLayer.path = path;
+        self.rSubSubwaveLayer.transform = transform;
+        CGPathRelease(path);
+    });
+}
+
+- (void)setSampleData:(float *)data length:(int)length{
+    [super setSampleData:data length:length];
+    
+    self.points[self.numberOfPoints - 1].x = self.bounds.size.width;
+    self.points[0].y = self.points[self.numberOfPoints - 1].y = self.waveOffset;
+}
+
+- (CGPathRef)createPathWithPoints:(CGPoint *)points
+                       pointCount:(NSUInteger)pointCount
+                           inRect:(CGRect)rect {
+    UIBezierPath *path;
+    
+    if (pointCount > 0){
+        path = [UIBezierPath bezierPath];
+        
+        // [path moveToPoint:CGPointMake(0, self.frame.size.height)];
+        [path moveToPoint:CGPointMake(0, self.waveOffset)];
+        
+        CGPoint p1 = self.points[0];
+        
+        [path addLineToPoint:p1];
+        
+        for (int i = 0; i<self.numberOfPoints; i++) {
+            CGPoint p2 = self.points[i];
+            CGPoint midPoint = midPointForPoints(p1, p2);
+            
+            [path addQuadCurveToPoint:midPoint controlPoint:controlPointForPoints(midPoint, p1)];
+            [path addQuadCurveToPoint:p2 controlPoint:controlPointForPoints(midPoint, p2)];
+            
+            p1 = self.points[i];
+        }
+        
+        // [path addLineToPoint:CGPointMake(self.frame.size.width, self.frame.size.height)];
+        [path addLineToPoint:CGPointMake(self.frame.size.width, self.waveOffset)];
+        // [path addLineToPoint:CGPointMake(0, self.frame.size.height)];
+        [path addLineToPoint:CGPointMake(0, self.waveOffset)];
+    }else{
+        float pixelFixer = self.bounds.size.width/self.numberOfPoints;
+        
+        if(cachedNumberOfPoints != self.numberOfPoints){
+            self.points = (CGPoint *)malloc(sizeof(CGPoint) * self.numberOfPoints);
+            cachedNumberOfPoints = self.numberOfPoints;
+            
+            for (int i = 0; i < self.numberOfPoints; i++){
+                self.points[i].x = i*pixelFixer;
+                self.points[i].y = self.waveOffset; //self.bounds.size.height/2;
+            }
+            
+            self.points[self.numberOfPoints - 1].x = self.bounds.size.width;
+            self.points[0].y = self.points[self.numberOfPoints - 1].y = self.waveOffset; //self.bounds.size.height/2;
+        }
+        
+        return [self createPathWithPoints:self.points
+                               pointCount:self.numberOfPoints
+                                   inRect:self.bounds];
+    }
+    
+    CGPathRef convertedPath = path.CGPath;
+    
+    return CGPathCreateCopy(convertedPath);
+}
+
+@end
+

--- a/MSHFView.m
+++ b/MSHFView.m
@@ -102,6 +102,11 @@ BOOL boost;
            subwaveColor:(UIColor *)subwaveColor {
 }
 
+- (void)updateWaveColor:(UIColor *)waveColor
+           subwaveColor:(UIColor *)subwaveColor
+        subSubwaveColor:(UIColor *)subSubwaveColor {
+}
+
 - (void)redraw {
   if (self.autoHide) {
     if (silentSince < ((long long)[[NSDate date] timeIntervalSince1970] - 1)) {

--- a/public/MSHFConfig.h
+++ b/public/MSHFConfig.h
@@ -2,6 +2,7 @@
 #import "MSHFDotView.h"
 #import "MSHFJelloView.h"
 #import "MSHFLineView.h"
+#import "MSHFSiriView.h"
 #import "MSHFView.h"
 
 @interface MSHFConfig : NSObject
@@ -22,6 +23,7 @@
 
 @property(nonatomic, strong) UIColor *waveColor;
 @property(nonatomic, strong) UIColor *subwaveColor;
+@property(nonatomic, strong) UIColor *subSubwaveColor;
 @property(nonatomic, strong) UIColor *calculatedColor;
 
 @property NSUInteger numberOfPoints;

--- a/public/MSHFSiriView.h
+++ b/public/MSHFSiriView.h
@@ -1,0 +1,16 @@
+#import <UIKit/UIKit.h>
+#import "MSHFView.h"
+#import "MSHFJelloLayer.h"
+
+@interface MSHFSiriView : MSHFView
+
+@property (nonatomic, strong) MSHFJelloLayer *waveLayer;
+@property (nonatomic, strong) MSHFJelloLayer *rWaveLayer;
+@property (nonatomic, strong) MSHFJelloLayer *subwaveLayer;
+@property (nonatomic, strong) MSHFJelloLayer *rSubwaveLayer;
+@property (nonatomic, strong) MSHFJelloLayer *subSubwaveLayer;
+@property (nonatomic, strong) MSHFJelloLayer *rSubSubwaveLayer;
+
+-(CGPathRef)createPathWithPoints:(CGPoint *)points pointCount:(NSUInteger)pointCount inRect:(CGRect)rect;
+
+@end

--- a/public/MSHFView.h
+++ b/public/MSHFView.h
@@ -34,12 +34,17 @@
 @property(nonatomic, strong) UIColor *calculatedColor;
 @property(nonatomic, strong) UIColor *waveColor;
 @property(nonatomic, strong) UIColor *subwaveColor;
+@property(nonatomic, strong) UIColor *subSubwaveColor;
 
 @property(nonatomic, retain) MSHFAudioSource *audioSource;
 @property(nonatomic, retain) MSHFAudioProcessing *audioProcessing;
 
 - (void)updateWaveColor:(UIColor *)waveColor
            subwaveColor:(UIColor *)subwaveColor;
+
+- (void)updateWaveColor:(UIColor *)waveColor
+           subwaveColor:(UIColor *)subwaveColor
+        subSubwaveColor:(UIColor *)subSubwaveColor;
 
 - (void)start;
 - (void)stop;


### PR DESCRIPTION
Added the Siri-like waveform I made for Mitsuha Infinity.
`colorMode == 2` would always return false, so I removed the different dynamic options since they both seemed to do the same thing and added the Siri color mode. Though, currently It only functions with the Siri View, I might add functionality to the other views like I had done for the Wave View on Mitsuha Infinity. The dynamic color mode works with the Siri View. Because the Siri View uses a screen blend mode to make it look close to how the Siri waveform looks, the dynamic color also appears whiter where it overlaps.